### PR TITLE
Fix saving images when assets folder is missing

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -1,15 +1,20 @@
+import os
 import requests
 
 
 def generate_image_from_prompt(prompt):
     url = "https://api.stability.ai/v2beta/stable-image/generate"
-    headers = {
-        "Authorization": "sk-CBsbVK5KVZYWwygFzyXdKWKdy0w1k0J7IJrfb7BjjxUDcNmm"}
+    api_key = os.environ.get("STABILITY_API_KEY")
+    if not api_key:
+        raise RuntimeError("STABILITY_API_KEY environment variable not set")
+    headers = {"Authorization": f"Bearer {api_key}"}
     data = {
         "prompt": prompt,
         "style": "anime"
     }
     r = requests.post(url, headers=headers, json=data)
+    r.raise_for_status()
+    os.makedirs("assets", exist_ok=True)
     with open("assets/generated.jpg", "wb") as f:
         f.write(r.content)
     return "assets/generated.jpg"

--- a/image_utils.py
+++ b/image_utils.py
@@ -1,16 +1,26 @@
+import os
 from PIL import Image, ImageFilter
 
 
+ASSETS_DIR = "assets"
+
+
+def ensure_assets_dir():
+    os.makedirs(ASSETS_DIR, exist_ok=True)
+
+
 def apply_filter(path, filter_type="BLUR"):
+    ensure_assets_dir()
     img = Image.open(path)
     if filter_type == "BLUR":
         img = img.filter(ImageFilter.BLUR)
     elif filter_type == "CONTOUR":
         img = img.filter(ImageFilter.CONTOUR)
-    img.save("assets/output.jpg")
+    img.save(os.path.join(ASSETS_DIR, "output.jpg"))
 
 
 def resize_image(path, size=(512, 512)):
+    ensure_assets_dir()
     img = Image.open(path)
     img = img.resize(size)
-    img.save("assets/resized.jpg")
+    img.save(os.path.join(ASSETS_DIR, "resized.jpg"))


### PR DESCRIPTION
## Summary
- ensure `assets` directory exists in image utility functions and image generator
- load API key from `STABILITY_API_KEY` environment variable and check request status

## Testing
- `python3 -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6840061484a08325a323f36db2623568