### PR TITLE
fix: ensure assets directory exists before saving

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -10,6 +10,8 @@ def generate_image_from_prompt(prompt):
         "style": "anime"
     }
     r = requests.post(url, headers=headers, json=data)
+    import os
+    os.makedirs("assets", exist_ok=True)
     with open("assets/generated.jpg", "wb") as f:
         f.write(r.content)
     return "assets/generated.jpg"


### PR DESCRIPTION
## Summary
- ensure the `assets` directory exists when saving generated images

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684006fb4e948325aa917dfe3120fd2e