### PR TITLE
docs: clean up duplicated metadata in buildozer spec

### DIFF
--- a/buildozer.spec
+++ b/buildozer.spec
@@ -7,13 +7,6 @@ requirements = python3,kivy,pillow,opencv-python,requests
 android.permissions = INTERNET
 
 # (str) Title of your application
-title = My Application
-
-# (str) Package name
-package.name = myapp
-
-# (str) Package domain (needed for android/ios packaging)
-package.domain = org.test
 
 # (str) Source code where the main.py live
 source.dir = .
@@ -43,7 +36,6 @@ version = 0.1
 
 # (list) Application requirements
 # comma separated e.g. requirements = sqlite3,kivy
-requirements = python3,kivy
 
 # (str) Custom source folders for requirements
 # Sets custom source for any requirements with recipes


### PR DESCRIPTION
## Summary
- remove duplicate metadata settings in `buildozer.spec`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684007f87e9883258df18b4ad423c536