### PR TITLE
Add assets directory with automatic creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+assets/*
+!assets/.gitkeep

--- a/generate.py
+++ b/generate.py
@@ -1,4 +1,5 @@
 import requests
+import os
 
 
 def generate_image_from_prompt(prompt):
@@ -10,6 +11,7 @@ def generate_image_from_prompt(prompt):
         "style": "anime"
     }
     r = requests.post(url, headers=headers, json=data)
+    os.makedirs("assets", exist_ok=True)
     with open("assets/generated.jpg", "wb") as f:
         f.write(r.content)
     return "assets/generated.jpg"

--- a/image_utils.py
+++ b/image_utils.py
@@ -1,4 +1,5 @@
 from PIL import Image, ImageFilter
+import os
 
 
 def apply_filter(path, filter_type="BLUR"):
@@ -7,10 +8,12 @@ def apply_filter(path, filter_type="BLUR"):
         img = img.filter(ImageFilter.BLUR)
     elif filter_type == "CONTOUR":
         img = img.filter(ImageFilter.CONTOUR)
+    os.makedirs("assets", exist_ok=True)
     img.save("assets/output.jpg")
 
 
 def resize_image(path, size=(512, 512)):
     img = Image.open(path)
     img = img.resize(size)
+    os.makedirs("assets", exist_ok=True)
     img.save("assets/resized.jpg")


### PR DESCRIPTION
## Summary
- add empty `assets/` directory with `.gitkeep`
- ignore generated assets in `.gitignore`
- ensure `generate_image_from_prompt` saves in an existing `assets/` folder
- ensure image utility functions create `assets/` before saving

## Testing
- `python -m py_compile generate.py`
- `python -m py_compile image_utils.py`
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_68400ae9d2848325a6421bdd9f77b25f