### PR TITLE
Add Windows EXE build script

### DIFF
--- a/READ.md
+++ b/READ.md
@@ -18,3 +18,17 @@ Un'app Android sviluppata in Python con Kivy che unisce strumenti di editing imm
 1. Clona il repository:
    ```bash
    git clone https://github.com/fabiofidone1978/photoshop_ai_app.git
+   cd photoshop_ai_app
+   
+   pip install -r requirements.txt
+   
+   # Avviare l'app
+   python main.py
+   ```
+
+2. Per generare l'eseguibile Windows (EXE) è possibile usare PyInstaller:
+   ```bash
+   pip install pyinstaller
+   ./build_exe.sh
+   ```
+   Il file verrà creato nella cartella `dist/` con nome `PhotoshopAI.exe`.

--- a/build_exe.sh
+++ b/build_exe.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# Rileva il separatore corretto per l'opzione --add-data
+sep=";"
+case "$(uname)" in
+    *Linux*|*Darwin*) sep=":" ;;
+esac
+
+pyinstaller --noconfirm --onefile --windowed \
+    --name PhotoshopAI \
+    --add-data "editor.kv${sep}." \
+    --add-data "gui.kv${sep}." \
+    --add-data "assets${sep}assets" \
+    --add-data "akivymd${sep}akivymd" \
+    main.py


### PR DESCRIPTION
## Summary
- add `build_exe.sh` for building a Windows executable using PyInstaller
- extend `READ.md` with instructions to install requirements and build the EXE

## Testing
- `bash -n build_exe.sh`


------
https://chatgpt.com/codex/tasks/task_e_684045ed86cc83258f7671adf742efe6